### PR TITLE
fix!(Makefile):create automation start, stop and restart for database…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,14 @@ stop-microservice:
 	docker-compose -f ./build/pkg/docker-compose.yml down -v
 
 restart-microservice: stop-microservice start-microservice
+
+
+
+start-database:
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml build
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml up
+
+stop-database:
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml down -v
+
+restart-database: stop-database start-database


### PR DESCRIPTION
# Task

Refactor Makefile for independent automation of database container.

## Description

Now u can provide following commands to operate the database container:
- `start-database` starts database container
- `stop-database` stops database container
- `restart-database` stops and then starts database container