### PR TITLE
Dockerization refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,14 @@ stop-microservice:
 	docker-compose -f ./build/pkg/docker-compose.yml down -v
 
 restart-microservice: stop-microservice start-microservice
+
+
+
+start-database:
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml build
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml up
+
+stop-database:
+	docker-compose -f ./third_party/build/pkg/docker-compose.yml down -v
+
+restart-database: stop-database start-database

--- a/build/pkg/docker-compose.yml
+++ b/build/pkg/docker-compose.yml
@@ -1,19 +1,8 @@
 version: "3.4"
 
 services:
-  db:
-    image: reindexer/reindexer
-    environment:
-      RX_DATABASE: /db
-    restart: always
-    ports:
-      - "9088:9088"
-      - "6534:6534"
-    container_name: reindexer_db
-
   microservice:
     build: ./build/pkg
-    depends_on:
-      - db
     ports:
       - "8080:80"
+    container_name: reindexer_microservice

--- a/third_party/build/pkg/docker-compose.yml
+++ b/third_party/build/pkg/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.4"
+
+services:
+  db:
+    image: reindexer/reindexer
+    environment:
+      RX_DATABASE: /db
+    restart: always
+    ports:
+      - "9088:9088"
+      - "6534:6534"
+    container_name: reindexer_db


### PR DESCRIPTION
# Task

Divide former docker-compose file into two separated files to provide both database and microservice independent operation and lifecycle.

## Description

Create new directory `third_party` for database docker-compose file, modify it and also modify former microservice docker-compose file to provide only microservice operation inside it.
